### PR TITLE
Remove pip (python package) and npm (JavaScript packages) caches

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -54,6 +54,9 @@ gem cleanup &>/dev/null
 echo 'Remove pip cache...'
 rm -rfv ~/Library/Caches/pip
 
+echo 'Cleanup npm cache...'
+npm cache clean --force
+
 if type "docker" > /dev/null; then
     echo 'Cleanup Docker'
     docker container prune -f

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -51,6 +51,9 @@ brew tap --repair &>/dev/null
 echo 'Cleanup any old versions of gems'
 gem cleanup &>/dev/null
 
+echo 'Remove pip cache...'
+rm -rfv ~/Library/Caches/pip
+
 if type "docker" > /dev/null; then
     echo 'Cleanup Docker'
     docker container prune -f


### PR DESCRIPTION
Removing pip cache.

pip doesn't has a command to clear its cache, so using rm to just delete the cache directory.