### PR TITLE
Option to cleanup without updating homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,22 @@
 
 A cleanup script for macOS that runs the following tasks:
 
-- Empty the Trash on All Mounted Volumes and the Main HDD
-- Clear System Log Files
-- Clear Adobe Cache Files
-- Cleanup iOS Applications
-- Remove iOS Device Backups
-- Cleanup Xcode Derived Data and Archives
-- Cleanup Homebrew Cache
-- Cleanup Any Old Versions of Gems
-- Cleanup Dangling Docker Images
-- Purge Inactive Memory
-- Cleanup npm Cache
-- Cleanup Yarn Cache
-- Cleanup Docker Images and Stopped Containers
-- Cleanup CocoaPods Cache Files
-- Cleanup Google Chrome Cache Files
-- Cleanup composer cache
+* Empty the Trash on All Mounted Volumes and the Main HDD
+* Clear System Log Files
+* Clear Adobe Cache Files
+* Cleanup iOS Applications
+* Remove iOS Device Backups
+* Cleanup Xcode Derived Data and Archives
+* Cleanup Homebrew Cache
+* Cleanup Any Old Versions of Gems
+* Cleanup Dangling Docker Images
+* Purge Inactive Memory
+* Cleanup npm Cache
+* Cleanup Yarn Cache
+* Cleanup Docker Images and Stopped Containers
+* Cleanup CocoaPods Cache Files
+* Cleanup Google Chrome Cache Files
+* Cleanup composer cache
 
 ## Install Automatically
 

--- a/README.md
+++ b/README.md
@@ -2,22 +2,22 @@
 
 A cleanup script for macOS that runs the following tasks:
 
-* Empty the Trash on All Mounted Volumes and the Main HDD
-* Clear System Log Files
-* Clear Adobe Cache Files
-* Cleanup iOS Applications
-* Remove iOS Device Backups
-* Cleanup Xcode Derived Data and Archives
-* Cleanup Homebrew Cache
-* Cleanup Any Old Versions of Gems
-* Cleanup Dangling Docker Images
-* Purge Inactive Memory
-* Cleanup npm Cache
-* Cleanup Yarn Cache
-* Cleanup Docker Images and Stopped Containers
-* Cleanup CocoaPods Cache Files
-* Cleanup Google Chrome Cache Files
-* Cleanup composer cache
+- Empty the Trash on All Mounted Volumes and the Main HDD
+- Clear System Log Files
+- Clear Adobe Cache Files
+- Cleanup iOS Applications
+- Remove iOS Device Backups
+- Cleanup Xcode Derived Data and Archives
+- Cleanup Homebrew Cache
+- Cleanup Any Old Versions of Gems
+- Cleanup Dangling Docker Images
+- Purge Inactive Memory
+- Cleanup npm Cache
+- Cleanup Yarn Cache
+- Cleanup Docker Images and Stopped Containers
+- Cleanup CocoaPods Cache Files
+- Cleanup Google Chrome Cache Files
+- Cleanup composer cache
 
 ## Install Automatically
 
@@ -49,6 +49,30 @@ curl -fsSL "https://raw.githubusercontent.com/fwartner/mac-cleanup/master/instal
 
 ```bash
 curl -fsSL "https://raw.githubusercontent.com/fwartner/mac-cleanup/master/installer.sh" | bash -s uninstall
+```
+
+## Usage Options
+
+Help menu:
+
+```
+$ cleanup -?
+
+A Mac Cleanup Utility by fwartner
+https://github.com/fwartner/mac-cleanup
+
+USAGE:
+ cleanup [FLAGS]
+
+FLAGS:
+-?,   prints help menu
+-n    no brew updates
+```
+
+Clean up without homebrew updates:
+
+```
+$ cleanup -n
 ```
 
 ## Contributors

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -10,6 +10,27 @@ bytesToHuman() {
     echo "$b$d ${S[$s]} of space was cleaned up"
 }
 
+# Default arguments
+doUpdates=true
+
+# Take in arguments
+# Can add more arguments in the future
+while getopts ":n" opt; do
+  case ${opt} in
+    n ) doUpdates=false
+      ;;
+    \? )
+        printf 'A Mac Cleanup Utility by fwartner\n'
+        printf 'https://github.com/fwartner/mac-cleanup\n\n'
+        printf 'USAGE:\n cleanup [FLAGS]\n\n'
+        printf 'FLAGS:\n'
+        printf -- '-?,   prints help menu\n'
+        printf -- '-n    no brew updates\n'
+        exit
+      ;;
+  esac
+done
+
 # Ask for the administrator password upfront
 sudo -v
 
@@ -64,10 +85,12 @@ if type "composer" &> /dev/null; then
 fi
 
 if type "brew" &>/dev/null; then
-    echo 'Update Homebrew Recipes...'
-    brew update
-    echo 'Upgrade and remove outdated formulae'
-    brew upgrade
+    if $doUpdates; then
+        echo 'Update Homebrew Recipes...'
+        brew update
+        echo 'Upgrade and remove outdated formulae'
+        brew upgrade
+    fi
     echo 'Cleanup Homebrew Cache...'
     brew cleanup -s &>/dev/null
     #brew cask cleanup &>/dev/null


### PR DESCRIPTION
Added flag arguments which can be further expand on in the future. Used built-in getops.
Getops automatically outputs help menu if given wrong flags.

- Added arguments menu
- Added arguments to readme

Utility can now be used same as before:
```
cleanup
```
With no updates:
```
cleanup -n
```

Menu overview.
```
$ ./cleanup.sh -h
A Mac Cleanup Utility by fwartner
https://github.com/fwartner/mac-cleanup

USAGE:
 cleanup [FLAGS]

FLAGS:
-?,   prints help menu
-n    no brew updates
```