### PR TITLE
update readme & reposition the pip in cleanup.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A cleanup script for macOS that runs the following tasks:
 * Cleanup Any Old Versions of Gems
 * Cleanup Dangling Docker Images
 * Purge Inactive Memory
+* Cleanup pip cache
 * Cleanup Pyenv-VirtualEnv Cache
 * Cleanup npm Cache
 * Cleanup Yarn Cache

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A cleanup script for macOS that runs the following tasks:
 * Cleanup Any Old Versions of Gems
 * Cleanup Dangling Docker Images
 * Purge Inactive Memory
+* Cleanup Pyenv-VirtualEnv Cache
 * Cleanup npm Cache
 * Cleanup Yarn Cache
 * Cleanup Docker Images and Stopped Containers

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -73,9 +73,6 @@ if type "xcrun" &>/dev/null; then
   xcrun simctl erase all
 fi
 
-echo 'Cleanup pip cache...'
-rm -rfv ~/Library/Caches/pip
-
 if [ -d "/Users/${HOST}/Library/Caches/CocoaPods" ]; then
     echo 'Cleanup CocoaPods cache...'
     rm -rfv ~/Library/Caches/CocoaPods/* &>/dev/null
@@ -121,6 +118,9 @@ if type "docker" &> /dev/null; then
     echo 'Cleanup Docker'
     docker system prune -af
 fi
+
+echo 'Cleanup pip cache...'
+rm -rfv ~/Library/Caches/pip
 
 if [ "$PYENV_VIRTUALENV_CACHE_PATH" ]; then
     echo 'Removing Pyenv-VirtualEnv Cache...'


### PR DESCRIPTION
I thought that this script is missing the python cleanup, so I forked it and trying to add it. Turned out that it's the Readme that's not updated. I also moved the pip cleanup to make it right before the Pyenv cache cleanup, since both are python related.