### PR TITLE
Cleanup iOS Device Logs

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -64,6 +64,7 @@ rm -rfv ~/Library/Application\ Support/MobileSync/Backup/* &>/dev/null
 echo 'Cleanup XCode Derived Data and Archives...'
 rm -rfv ~/Library/Developer/Xcode/DerivedData/* &>/dev/null
 rm -rfv ~/Library/Developer/Xcode/Archives/* &>/dev/null
+rm -rfv ~/Library/Developer/Xcode/iOS Device Logs/* &>/dev/null
 
 if type "xcrun" &>/dev/null; then
   echo 'Cleanup iOS Simulators...'


### PR DESCRIPTION
I had a lot of iOS Device Logs on `~/Library/Developer/Xcode/` that I think can be removed as well when we clean up the system :)