### PR TITLE
clear google chrome cache files

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -69,6 +69,9 @@ rm -rfv ~/Library/Logs/CoreSimulator/* &>/dev/null
 echo 'Clear Adobe Cache Files...'
 sudo rm -rfv ~/Library/Application\ Support/Adobe/Common/Media\ Cache\ Files/* &>/dev/null
 
+echo 'Clear Google Chrome Cache Files...'
+sudo rm -rfv ~/Library/Application\ Support/Google/Chrome/Default/Application\ Cache/* &>/dev/null
+
 echo 'Cleanup iOS Applications...'
 rm -rfv ~/Music/iTunes/iTunes\ Media/Mobile\ Applications/* &>/dev/null
 


### PR DESCRIPTION
In addition to the `~/Library/Caches` Google Chrome uses this directory for additional caches.
It doesn't contain session data or similar, so it's okay to purge.